### PR TITLE
chore(deploy): Switch from npm to yarn for Firebase deployment workflow

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -17,13 +17,13 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-          cache: 'npm'
+          cache: 'yarn'
       
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
       
       - name: Build Next.js app
-        run: npm run build
+        run: yarn build
       
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0


### PR DESCRIPTION
- Updated the GitHub Actions workflow to use yarn instead of npm for dependency installation and build processes.
- Changed cache strategy to 'yarn' and adjusted commands for installing dependencies and building the Next.js app.